### PR TITLE
Refactor doc

### DIFF
--- a/src-tauri/src/editor/io.rs
+++ b/src-tauri/src/editor/io.rs
@@ -1,6 +1,7 @@
 //! This module provides IO related functions for the app.
 use std::fs; //Filesystem module
 use std::path::PathBuf; //PathBuf datatype to store path strings
+use uuid::Uuid; //Uuid module to generate unique ids
 // use tauri_plugin_dialog::DialogExt; //DialogExt trait to show dialog boxes
 
 use dirs; //dirs module to get the path of the documents directory
@@ -160,7 +161,7 @@ pub fn save_document(id: String, title: String, content: String) -> Result<Strin
     let full_markdown = format!("# {}\n\n{}", title, markdown_content);
 
     // Use .md extension instead of .json
-    let safe_filename = sanitize_filename::sanitize(format!("{}.md", id));
+    let safe_filename = sanitize_filename::sanitize(format!("{}.md", title));
     let file_path = trove_dir.join(&safe_filename);
 
     // Write markdown content directly to file
@@ -172,23 +173,25 @@ pub fn save_document(id: String, title: String, content: String) -> Result<Strin
 
 #[tauri::command]
 pub fn delete_document(id: String) -> Result<Option<DocumentData>, String> {
-    let mut recent_files = RECENT_FILES
-        .lock()
-        .map_err(|e| format!("Failed to lock RECENT_FILES: {}", e))?;
-    recent_files.retain(|doc| doc.id != id);
-    let trove_dir = get_trove_dir("Untitled_Trove");
-    let filename = sanitize_filename::sanitize(format!("{}.md", id));
-    let file_path = trove_dir.join(&filename);
-
-    // Remove the tab and get its index
     let mut tabs = TABS
         .lock()
         .map_err(|e| format!("Failed to lock TABS: {}", e))?;
+    let mut recent_files = RECENT_FILES
+        .lock()
+        .map_err(|e| format!("Failed to lock RECENT_FILES: {}", e))?;
+    let tab_title = tabs.get(&id)
+        .map(|tab| tab.title.clone())
+        .unwrap();
+    recent_files.retain(|doc| doc.id != id);
+    let trove_dir = get_trove_dir("Untitled_Trove");
+    let filename = sanitize_filename::sanitize(format!("{}.md", tab_title));
+    let file_path = trove_dir.join(&filename);
 
+    // Remove the tab and get its index
     if let Some((index, _, _)) = tabs.shift_remove_full(&id) {
         // Get the tab at the same index (the one that shifted up)
         // If no tab at that index, get the last tab
-        let next_tab = if let Some((next_id, _)) = tabs.get_index(index).or_else(|| tabs.last()) {
+        let next_tab = if let Some((next_id, next_tab)) = tabs.get_index(index).or_else(|| tabs.last()) {
             // Update current open tab
             let mut current_open_tab = CURRENT_OPEN_TAB
                 .lock()
@@ -196,7 +199,7 @@ pub fn delete_document(id: String) -> Result<Option<DocumentData>, String> {
             *current_open_tab = next_id.clone();
 
             // Get the document content for the next tab
-            get_document_content(next_id.clone())?
+            get_document_content(next_id.clone(), next_tab.title.clone())?
         } else {
             None
         };
@@ -219,9 +222,9 @@ pub fn delete_document(id: String) -> Result<Option<DocumentData>, String> {
 }
 
 #[tauri::command]
-pub fn get_document_content(id: String) -> Result<Option<DocumentData>, String> {
+pub fn get_document_content(id: String, title: String) -> Result<Option<DocumentData>, String> {
     let trove_dir = get_trove_dir("Untitled_Trove");
-    let file_path = trove_dir.join(format!("{}.md", id));
+    let file_path = trove_dir.join(format!("{}.md", title));
 
     if !file_path.exists() {
         return Ok(None);
@@ -271,7 +274,7 @@ pub fn load_last_open_tabs() -> Result<Vec<DocumentData>, String> {
                         tabs.clear();
                         for tab in user_data.tabs {
                             // Try to load each document by ID
-                            match get_document_content(tab.id.clone()) {
+                            match get_document_content(tab.id.clone(), tab.title.clone()) {
                                 Ok(Some(doc)) => {
                                     last_open_files.push(doc);
                                     tabs.insert(tab.id.clone(), tab.clone());
@@ -298,13 +301,14 @@ pub fn load_last_open_tabs() -> Result<Vec<DocumentData>, String> {
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "md"))
             .filter_map(|entry| {
                 let path = entry.path();
-                let id = path
+                let title = path
                     .file_stem()
                     .and_then(|s| s.to_str())
                     .map(String::from)
                     .unwrap_or_default();
 
-                get_document_content(id).ok().flatten()
+                let id = Uuid::new_v4().to_string();
+                get_document_content(id, title).ok().flatten()
             })
             .collect(),
         Err(e) => return Err(format!("Failed to read directory: {}", e)),

--- a/src-tauri/src/editor/io.rs
+++ b/src-tauri/src/editor/io.rs
@@ -158,14 +158,14 @@ pub fn save_document(id: String, title: String, content: String) -> Result<Strin
     let markdown_content = markdown_handler::html_to_markdown(&content);
 
     // Add title as heading
-    let full_markdown = format!("# {}\n\n{}", title, markdown_content);
+    // let full_markdown = format!("# {}\n\n{}", title, markdown_content);
 
     // Use .md extension instead of .json
     let safe_filename = sanitize_filename::sanitize(format!("{}.md", title));
     let file_path = trove_dir.join(&safe_filename);
 
     // Write markdown content directly to file
-    match fs::write(&file_path, full_markdown) {
+    match fs::write(&file_path, markdown_content) {
         Ok(_) => Ok(file_path.to_string_lossy().to_string()),
         Err(e) => Err(format!("Failed to write file: {}", e)),
     }
@@ -232,12 +232,12 @@ pub fn get_document_content(id: String, title: String) -> Result<Option<Document
 
     match fs::read_to_string(&file_path) {
         Ok(content) => {
-            let (title, html_output) = markdown_handler::markdown_to_html(&content);
+            let html_output = markdown_handler::markdown_to_html(&content);
 
             Ok(Some(DocumentData {
-                id: id.clone(),
+                id,
                 title,
-                content: html_output, // Now returning HTML instead of markdown
+                content: html_output,
             }))
         }
         Err(e) => Err(format!("Failed to read file: {}", e)),

--- a/src-tauri/src/editor/markdown_handler.rs
+++ b/src-tauri/src/editor/markdown_handler.rs
@@ -10,23 +10,9 @@ pub fn html_to_markdown(html: &str) -> String {
     markdown.replace(r"\==", "==")
 }
 
-pub fn markdown_to_html(markdown: &str) -> (String, String) {
+pub fn markdown_to_html(markdown: &str) -> String {
     let re = Regex::new(r"==(.+?)==").unwrap();
     let processed_markdown = re.replace_all(markdown, r"<mark>$1</mark>").to_string();
-    let lines: Vec<&str> = processed_markdown.lines().collect();
-    // Extract title from first line (assumes "# Title" format)
-    let title = if !lines.is_empty() && lines[0].starts_with("# ") {
-        lines[0][2..].to_string()
-    } else {
-        "Untitled".to_string()
-    };
-
-    // Get content without the title
-    let markdown_content = if !lines.is_empty() {
-        lines[2..].join("\n")
-    } else {
-        String::new()
-    };
     
     // Convert markdown to HTML
     let mut options = Options::empty();
@@ -36,8 +22,8 @@ pub fn markdown_to_html(markdown: &str) -> (String, String) {
     options.insert(Options::ENABLE_TASKLISTS);
     options.insert(Options::ENABLE_SMART_PUNCTUATION);
 
-    let parser = Parser::new_ext(&markdown_content, options);
+    let parser = Parser::new_ext(&processed_markdown, options);
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
-    (title, html_output)
+    html_output
 }

--- a/src/components/document-tab-item.svelte
+++ b/src/components/document-tab-item.svelte
@@ -22,7 +22,7 @@ let charCount: number = $state(0);
 onMount(async () => {
     documentTitle = tab.title;
     // content = tab.content;
-    const doc = await DocumentService.loadDocument(tab.id);
+    const doc = await DocumentService.loadDocument(tab.id, tab.title);
 
     if(!doc) return;
     documentContent = doc.content;

--- a/src/components/document-tab-item.svelte
+++ b/src/components/document-tab-item.svelte
@@ -35,7 +35,7 @@ const handleTitleChange = (event: Event) => {
     documentTitle = target.value;
     TabService.updateTabTitleById(tab.id, target.value);
 
-    saveDocument();
+    // saveDocument();
 }
 
 let saveTimeout: number | undefined;

--- a/src/services/api.interface.ts
+++ b/src/services/api.interface.ts
@@ -8,7 +8,7 @@ export interface IApiServiceProvider {
 
     sendCurrentOpenTab(tabId: string): Promise<void>;
 
-    getDocumentContent(tabId: string): Promise<Document | null>;
+    getDocumentContent(tabId: string, tabTitle: string): Promise<Document | null>;
 
     saveDocument({
         documentId,

--- a/src/services/document.service.ts
+++ b/src/services/document.service.ts
@@ -91,13 +91,11 @@ const saveDocument = async ({
     });
 };
 
-const loadDocument = async (documentId: string): Promise<Document | null> => {
+const loadDocument = async (documentId: string, documentTitle: string): Promise<Document | null> => {
     try {
-        const doc = await apiProvider.getDocumentContent(documentId);
+        const doc = await apiProvider.getDocumentContent(documentId, documentTitle);
         if (!doc) return null;
 
-        // No need to parse JSON since content is already HTML
-        // if (isValidJSON(doc.content)) doc.content = JSON.parse(doc.content);
         return doc;
     } catch (error) {
         console.error("Failed to load document:", error);

--- a/src/services/tauri-invoke.service.ts
+++ b/src/services/tauri-invoke.service.ts
@@ -16,9 +16,10 @@ export class TauriInvokeServiceProvider implements IApiServiceProvider {
         await invoke("send_current_open_tab", { id: tabId });
     }
 
-    async getDocumentContent(tabId: string): Promise<Document | null> {
+    async getDocumentContent(tabId: string, tabTitle: string): Promise<Document | null> {
         return await invoke<Document | null>("get_document_content", {
             id: tabId,
+            title: tabTitle
         });
     }
 


### PR DESCRIPTION
I have separated tab ids and document names. Now document names are saved as title names of the note.
One bug that has been spawned after this commit is that when u change the title of the same file, a new file is generated instead of editing the same file.